### PR TITLE
Only check binary dependency when audio is played

### DIFF
--- a/google_speech/__init__.py
+++ b/google_speech/__init__.py
@@ -137,6 +137,8 @@ class Speech:
 
   def play(self, sox_effects=()):
     """ Play a speech. """
+    # check deps
+    bin_dep.check_bin_dependency(("sox",))
 
     # build the segments
     preloader_threads = []
@@ -337,9 +339,6 @@ def cl_main():
   else:
     speech.play(args.sox_effects)
 
-
-# check deps
-bin_dep.check_bin_dependency(("sox",))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In the current implementation, the audio is only loaded after `play` or `output` is called, so the check is done before the program make any HTTP request.

I don't have `sox` installed, but I have another audio player, and I want to use that, so it should not error out.