### PR TITLE
Added `-s/--max-segment-size` flag to change the value of `MAX_SEGMENT_SIZE`.

### DIFF
--- a/google_speech/__init__.py
+++ b/google_speech/__init__.py
@@ -59,7 +59,7 @@ class Speech:
 
   CLEAN_MULTIPLE_SPACES_REGEX = re.compile("\s{2,}")
 
-  def __init__(self, text, lang, max_segment_size):
+  def __init__(self, text, lang, max_segment_size = 100):
     self.text = self.cleanSpaces(text)
     self.lang = lang
     self.max_segment_size = max_segment_size


### PR DESCRIPTION
# Motivation

Currently, `MAX_SEGMENT_SIZE` is hard-coded in `Speech` class. The problem is the default value `100` is too small in some situations (related comment: [#21](https://github.com/desbma/GoogleSpeech/issues/21#issuecomment-526799140)).

This PR adds `-s/--max-segment-size` flag to let users customize the value of `Speech.MAX_SEGMENT_SIZE`.

# What's Changed

- Removed `Speech.MAX_SEGMENT_SIZE` class field.

- Instead, `Speech` class now has the `max_segment_size` instance field and the constructor receives it. (Because the signature of the constructor is now `def __init__(self, text, lang, max_segment_size = 100):`, Python API is backward compatible.)

- `Speech.splitText()` static method now additionally receives `max_segment_size` (because it cannot access `self`).

- Added `-s/--max-segment-size <positive_int>` flag to specify the value of `Speech.max_segment_size`. The default value is `100` (for backward compatibility).

- Added `check_positive()` function which validates the argument of `-s/--max-segment-size` flag. Also added its unit tests.

- Added a relatively long comment to `SpeechSegment.play()`. Logic isn't changed at all. This is because, in my environment (M1 mac), the existing unit tests didn't pass.
